### PR TITLE
add @Child property for one-to-one relation

### DIFF
--- a/Sources/FluentBenchmark/FluentBenchmarker.swift
+++ b/Sources/FluentBenchmark/FluentBenchmarker.swift
@@ -22,6 +22,7 @@ public final class FluentBenchmarker {
         try self.testAggregate()
         try self.testArray()
         try self.testBatch()
+        try self.testChild()
         try self.testChildren()
         try self.testCodable()
         try self.testChunk()

--- a/Sources/FluentBenchmark/SolarSystem/Governor.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Governor.swift
@@ -1,0 +1,66 @@
+import FluentKit
+
+public final class Governor: Model {
+    public static let schema = "governors"
+
+    @ID(key: .id)
+    public var id: UUID?
+
+    @Field(key: "name")
+    public var name: String
+
+    @Parent(key: "planet_id")
+    public var planet: Planet
+
+    public init() { }
+
+    public init(id: IDValue? = nil, name: String) {
+        self.id = id
+        self.name = name
+    }
+
+    public init(id: IDValue? = nil, name: String, planetId: UUID) {
+        self.id = id
+        self.name = name
+        self.$planet.id = planetId
+    }
+}
+
+public struct GovernorMigration: Migration {
+    public func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("governors")
+            .field("id", .uuid, .identifier(auto: false))
+            .field("name", .string, .required)
+            .field("planet_id", .uuid, .required, .references("planets", "id"))
+            .create()
+    }
+
+    public func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("governors").delete()
+    }
+}
+
+public struct GovernorSeed: Migration {
+    public init() { }
+
+    public func prepare(on database: Database) -> EventLoopFuture<Void> {
+        Planet.query(on: database).all().flatMap { planets in
+            .andAllSucceed(planets.map { planet in
+                let governor: Governor
+                switch planet.name {
+                case "Mars":
+                    governor = .init(name: "John Doe")
+                case "Earth":
+                    governor = .init(name: "Jane Doe")
+                default:
+                    governor = .init(name: "")
+                }
+                return planet.$governor.create(governor, on: database)
+            }, on: database.eventLoop)
+        }
+    }
+
+    public func revert(on database: Database) -> EventLoopFuture<Void> {
+        Governor.query(on: database).delete()
+    }
+}

--- a/Sources/FluentBenchmark/SolarSystem/Planet.swift
+++ b/Sources/FluentBenchmark/SolarSystem/Planet.swift
@@ -14,6 +14,9 @@ public final class Planet: Model {
 
     @Children(for: \.$planet)
     public var moons: [Moon]
+    
+    @Child(for: \.$planet)
+    public var governor: Governor
 
     @Siblings(through: PlanetTag.self, from: \.$planet, to: \.$tag)
     public var tags: [Tag]

--- a/Sources/FluentBenchmark/Tests/ChildTests.swift
+++ b/Sources/FluentBenchmark/Tests/ChildTests.swift
@@ -1,0 +1,137 @@
+extension FluentBenchmarker {
+    public func testChild() throws {
+        try self.testChild_with()
+    }
+
+    private func testChild_with() throws {
+        try self.runTest(#function, [
+            FooMigration(),
+            BarMigration(),
+            BazMigration()
+        ]) {
+            let foo = Foo(name: "a")
+            try foo.save(on: self.database).wait()
+            let bar = Bar(bar: 42, fooID: foo.id!)
+            try bar.save(on: self.database).wait()
+            let baz = Baz(baz: 3.14, fooID: foo.id!)
+            try baz.save(on: self.database).wait()
+
+            let foos = try Foo.query(on: self.database)
+                .with(\.$bar)
+                .with(\.$baz)
+                .all().wait()
+
+            for foo in foos {
+                XCTAssertEqual(foo.bar.bar, 42)
+                XCTAssertEqual(foo.baz.baz, 3.14)
+            }
+        }
+    }
+}
+
+
+private final class Foo: Model {
+    static let schema = "foos"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "name")
+    var name: String
+
+    @Child(for: \.$foo)
+    var bar: Bar
+
+    @Child(for: \.$foo)
+    var baz: Baz
+
+    init() { }
+
+    init(id: IDValue? = nil, name: String) {
+        self.id = id
+        self.name = name
+    }
+}
+
+private struct FooMigration: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("foos")
+            .field("id", .uuid, .identifier(auto: false))
+            .field("name", .string, .required)
+            .create()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("foos").delete()
+    }
+}
+
+private final class Bar: Model {
+    static let schema = "bars"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "bar")
+    var bar: Int
+
+    @Parent(key: "foo_id")
+    var foo: Foo
+
+    init() { }
+
+    init(id: IDValue? = nil, bar: Int, fooID: Foo.IDValue) {
+        self.id = id
+        self.bar = bar
+        self.$foo.id = fooID
+    }
+}
+
+private struct BarMigration: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("bars")
+            .field("id", .uuid, .identifier(auto: false))
+            .field("bar", .int, .required)
+            .field("foo_id", .uuid, .required)
+            .create()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("bars").delete()
+    }
+}
+
+private final class Baz: Model {
+    static let schema = "bazs"
+
+    @ID(key: .id)
+    var id: UUID?
+
+    @Field(key: "baz")
+    var baz: Double
+
+    @Parent(key: "foo_id")
+    var foo: Foo
+
+    init() { }
+
+    init(id: IDValue? = nil, baz: Double, fooID: Foo.IDValue) {
+        self.id = id
+        self.baz = baz
+        self.$foo.id = fooID
+    }
+}
+
+private struct BazMigration: Migration {
+    func prepare(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("bazs")
+            .field("id", .uuid, .identifier(auto: false))
+            .field("baz", .double, .required)
+            .field("foo_id", .uuid, .required)
+            .create()
+    }
+
+    func revert(on database: Database) -> EventLoopFuture<Void> {
+        database.schema("bazs").delete()
+    }
+}

--- a/Sources/FluentKit/Properties/Child.swift
+++ b/Sources/FluentKit/Properties/Child.swift
@@ -1,0 +1,254 @@
+extension Model {
+    public typealias Child<To> = ChildProperty<Self, To>
+        where To: FluentKit.Model
+}
+
+// MARK: Type
+
+@propertyWrapper
+public final class ChildProperty<From, To>
+    where From: Model, To: Model
+{
+    public enum Key {
+        case required(KeyPath<To, To.Parent<From>>)
+        case optional(KeyPath<To, To.OptionalParent<From>>)
+    }
+
+    public let parentKey: Key
+    var idValue: From.IDValue?
+
+    public var value: To?
+
+    public init(for parent: KeyPath<To, To.Parent<From>>) {
+        self.parentKey = .required(parent)
+    }
+
+    public init(for optionalParent: KeyPath<To, To.OptionalParent<From>>) {
+        self.parentKey = .optional(optionalParent)
+    }
+
+    public var wrappedValue: To {
+        get {
+            guard let value = self.value else {
+                fatalError("Child relation not eager loaded, use $ prefix to access: \(name)")
+            }
+            return value
+        }
+        set {
+            fatalError("Child relation is get-only.")
+        }
+    }
+
+    public var projectedValue: ChildProperty<From, To> {
+        return self
+    }
+    
+    public var fromId: From.IDValue? {
+        return self.idValue
+    }
+
+    public func query(on database: Database) -> QueryBuilder<To> {
+        guard let id = self.idValue else {
+            fatalError("Cannot query child relation from unsaved model.")
+        }
+        let builder = To.query(on: database)
+        switch self.parentKey {
+        case .optional(let optional):
+            builder.filter(optional.appending(path: \.$id) == id)
+        case .required(let required):
+            builder.filter(required.appending(path: \.$id) == id)
+        }
+        return builder
+    }
+
+    public func create(_ to: [To], on database: Database) -> EventLoopFuture<Void> {
+        guard let id = self.idValue else {
+            fatalError("Cannot save child to unsaved model.")
+        }
+        to.forEach {
+            switch self.parentKey {
+            case .required(let keyPath):
+                $0[keyPath: keyPath].id = id
+            case .optional(let keyPath):
+                $0[keyPath: keyPath].id = id
+            }
+        }
+        return to.create(on: database)
+    }
+
+    public func create(_ to: To, on database: Database) -> EventLoopFuture<Void> {
+        guard let id = self.idValue else {
+            fatalError("Cannot save child to unsaved model.")
+        }
+        switch self.parentKey {
+        case .required(let keyPath):
+            to[keyPath: keyPath].id = id
+        case .optional(let keyPath):
+            to[keyPath: keyPath].id = id
+        }
+        return to.create(on: database)
+    }
+}
+
+extension ChildProperty: CustomStringConvertible {
+    public var description: String {
+        self.name
+    }
+}
+
+// MARK: Property
+
+extension ChildProperty: AnyProperty { }
+
+extension ChildProperty: Property {
+    public typealias Model = From
+    public typealias Value = To
+}
+
+// MARK: Database
+
+extension ChildProperty: AnyDatabaseProperty {
+    public var keys: [FieldKey] {
+        []
+    }
+
+    public func input(to input: DatabaseInput) {
+        // child never has input
+    }
+
+    public func output(from output: DatabaseOutput) throws {
+        let key = From()._$id.field.key
+        if output.contains(key) {
+            self.idValue = try output.decode(key, as: From.IDValue.self)
+        }
+    }
+}
+
+// MARK: Codable
+
+extension ChildProperty: AnyCodableProperty {
+    public func encode(to encoder: Encoder) throws {
+        if let rows = self.value {
+            var container = encoder.singleValueContainer()
+            try container.encode(rows)
+        }
+    }
+
+    public func decode(from decoder: Decoder) throws {
+        // don't decode
+    }
+}
+
+// MARK: Relation
+
+extension ChildProperty: Relation {
+    public var name: String {
+        "Child<\(From.self), \(To.self)>(for: \(self.parentKey))"
+    }
+
+    public func load(on database: Database) -> EventLoopFuture<Void> {
+        self.query(on: database).first().map {
+            self.value = $0
+        }
+    }
+}
+
+extension ChildProperty.Key: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .optional(let keyPath):
+            return To.path(for: keyPath.appending(path: \.$id)).description
+        case .required(let keyPath):
+            return To.path(for: keyPath.appending(path: \.$id)).description
+        }
+    }
+}
+
+// MARK: Eager Loadable
+
+extension ChildProperty: EagerLoadable {
+    public static func eagerLoad<Builder>(
+        _ relationKey: KeyPath<From, From.Child<To>>,
+        to builder: Builder
+    )
+        where Builder: EagerLoadBuilder, Builder.Model == From
+    {
+        let loader = ChildEagerLoader(relationKey: relationKey)
+        builder.add(loader: loader)
+    }
+
+
+    public static func eagerLoad<Loader, Builder>(
+        _ loader: Loader,
+        through: KeyPath<From, From.Child<To>>,
+        to builder: Builder
+    ) where
+        Loader: EagerLoader,
+        Loader.Model == To,
+        Builder: EagerLoadBuilder,
+        Builder.Model == From
+    {
+        let loader = ThroughChildEagerLoader(relationKey: through, loader: loader)
+        builder.add(loader: loader)
+    }
+}
+
+private struct ChildEagerLoader<From, To>: EagerLoader
+    where From: Model, To: Model
+{
+    let relationKey: KeyPath<From, From.Child<To>>
+
+    func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
+        let ids = models.map { $0.id! }
+
+        let builder = To.query(on: database)
+        let parentKey = From()[keyPath: self.relationKey].parentKey
+        switch parentKey {
+        case .optional(let optional):
+            builder.filter(optional.appending(path: \.$id) ~~ Set(ids))
+        case .required(let required):
+            builder.filter(required.appending(path: \.$id) ~~ Set(ids))
+        }
+        return builder.all().map {
+            for model in models {
+                let id = model[keyPath: self.relationKey].idValue!
+                let children = $0.filter { child in
+                    switch parentKey {
+                    case .optional(let optional):
+                        return child[keyPath: optional].id == id
+                    case .required(let required):
+                        return child[keyPath: required].id == id
+                    }
+                }
+                model[keyPath: self.relationKey].value = children.first
+            }
+        }
+//        return builder.all().map {
+//            for model in models {
+//                let id = model[keyPath: self.relationKey].idValue!
+//                model[keyPath: self.relationKey].value = $0.filter { child in
+//                    switch parentKey {
+//                    case .optional(let optional):
+//                        return child[keyPath: optional].id == id
+//                    case .required(let required):
+//                        return child[keyPath: required].id == id
+//                    }
+//                }
+//            }
+//        }
+    }
+}
+
+private struct ThroughChildEagerLoader<From, Through, Loader>: EagerLoader
+    where From: Model, Loader: EagerLoader, Loader.Model == Through
+{
+    let relationKey: KeyPath<From, From.Child<Through>>
+    let loader: Loader
+
+    func run(models: [From], on database: Database) -> EventLoopFuture<Void> {
+        let throughs = models.map {
+            $0[keyPath: self.relationKey].value!
+        }
+        return self.loader.run(models: throughs, on: database)
+    }
+}

--- a/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
+++ b/Sources/FluentKit/Query/Builder/QueryBuilder+Join.swift
@@ -53,6 +53,51 @@ extension QueryBuilder {
     ) -> Self {
         join(from: Model.self, parent: parent, method: method)
     }
+    
+    /// This will join a foreign table based on a `@Child` relation
+    ///
+    /// This will not decode the joined data, but can be used in order to filter.
+    ///
+    ///     Planet.query(on: db)
+    ///         .join(child: \.$governor)
+    ///         .filter(Governor.self, \Governor.$name == "John Doe")
+    ///
+    /// - Parameters:
+    ///   - model: The `Model` to join from
+    ///   - child: The `ChildProperty` to join
+    ///   - method: The method to use. The default is an inner join
+    /// - Returns: A new `QueryBuilder`
+    @discardableResult
+    public func join<From, To>(
+        from model: From.Type,
+        child: KeyPath<From, ChildProperty<From, To>>,
+        method: DatabaseQuery.Join.Method = .inner
+    ) -> Self {
+        switch From()[keyPath: child].parentKey {
+        case .optional(let parent): return join(To.self, on: \From._$id == parent.appending(path: \.$id), method: method)
+        case .required(let parent): return join(To.self, on: \From._$id == parent.appending(path: \.$id), method: method)
+        }
+    }
+
+    /// This will join a foreign table based on a `@Child` relation
+    ///
+    /// This will not decode the joined data, but can be used in order to filter.
+    ///
+    ///     Planet.query(on: db)
+    ///         .join(child: \.$governor)
+    ///         .filter(Governor.self, \Governor.$name == "John Doe")
+    ///
+    /// - Parameters:
+    ///   - child: The `ChildProperty` to join
+    ///   - method: The method to use. The default is an inner join
+    /// - Returns: A new `QueryBuilder`
+    @discardableResult
+    public func join<To>(
+        child: KeyPath<Model, ChildProperty<Model, To>>,
+        method: DatabaseQuery.Join.Method = .inner
+    ) -> Self {
+        join(from: Model.self, child: child, method: method)
+    }
 
     /// This will join a foreign table based on a `@Children` relation
     ///

--- a/Tests/FluentKitTests/FluentKitTests.swift
+++ b/Tests/FluentKitTests/FluentKitTests.swift
@@ -67,6 +67,11 @@ final class FluentKitTests: XCTestCase {
 
     func testJoins() throws {
         let db = DummyDatabaseForTestSQLSerializer()
+        _ = try Planet.query(on: db).join(child: \Planet.$governor).all().wait()
+        XCTAssertEqual(db.sqlSerializers.count, 1)
+        XCTAssertEqual(db.sqlSerializers.first?.sql.contains(#"INNER JOIN "governors" ON "planets"."id" = "governors"."planet_id"#), true)
+        db.reset()
+        
         _ = try Planet.query(on: db).join(children: \Planet.$moons).all().wait()
         XCTAssertEqual(db.sqlSerializers.count, 1)
         XCTAssertEqual(db.sqlSerializers.first?.sql.contains(#"INNER JOIN "moons" ON "planets"."id" = "moons"."planet_id"#), true)


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Solves Issue: https://github.com/vapor/fluent-kit/issues/74
Duplicates PR:  https://github.com/taikoo/fluent-kit/commit/bce3a41ac980f016c30529da64c9397523a2cca4

Change implements new `@Child` property for one-to-one relations. Implementation is based on existing `@Children` property.

See test files `ChildTests.swift` and `Governor.swift` fro more details.

<!-- When this PR is merged, the title and body will be -->
add @Child property for one-to-one relation

<!-- used to generate a release automatically. -->
